### PR TITLE
generate rpc: custom split reward

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -305,7 +305,7 @@ static RPCMethod generatetoaddress()
 static RPCMethod generateblock()
 {
     return RPCMethod{"generateblock",
-        "Mine a block with set of ordered transactions or mempool transactions to a specified group of addresses or descriptors and return the block hash.\n"
+        "Mine a block with set of ordered transactions or mempool transactions to a specified group of addresses or descriptors and the corresponding amount to each one, and return the block hash.\n"
         "Transaction fees are not collected in the block reward.",
         {
             {"output", RPCArg::Type::ARR, RPCArg::Optional::NO, "The address or descriptor to split, in equal parts, the coinbase reward among.\n"
@@ -339,6 +339,7 @@ static RPCMethod generateblock()
             + HelpExampleCli("generateblock", R"("myaddress" '["rawtx", "mempool_txid"]')")
             + HelpExampleCli("generateblock", R"("myaddress" [])")
             + HelpExampleCli("generateblock", R"('["myaddress1", "myaddress2"]')")
+            + HelpExampleCli("generateblock", R"('[{"myaddress1":10},{"myaddress2":20}]')")
         },
         [](const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
 {
@@ -357,12 +358,20 @@ static RPCMethod generateblock()
     CScript coinbase_output_script;
     std::string error;
     std::vector<CScript> coinbase_outputs_scripts;
+    std::vector<CAmount> custom_rewards;
+    std::string address_or_descriptor_str;
     if (address_or_descriptor.empty()) {
         coinbase_outputs_scripts.push_back(CScript() << OP_RETURN);
     }
     for (size_t i = 0; i < address_or_descriptor.size(); i++) {
-        if (!getScriptFromDescriptor(address_or_descriptor[i].get_str(), coinbase_output_script, error)) {
-            const auto destination = DecodeDestination(address_or_descriptor[i].get_str());
+        if (address_or_descriptor[i].isObject()){
+            address_or_descriptor_str = address_or_descriptor[i].getKeys()[0];
+            custom_rewards.push_back(address_or_descriptor[i].getValues()[0].getInt<CAmount>());
+        } else {
+            address_or_descriptor_str = address_or_descriptor[i].get_str();
+        }
+        if (!getScriptFromDescriptor(address_or_descriptor_str, coinbase_output_script, error)) {
+            const auto destination = DecodeDestination(address_or_descriptor_str);
             if (!IsValidDestination(destination)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address or descriptor");
             }
@@ -418,8 +427,6 @@ static RPCMethod generateblock()
 
         const auto num_outputs = coinbase_outputs_scripts.size();
         CAmount total_reward = block.vtx[0]->vout[0].nValue;
-        CAmount reward_parted = total_reward / num_outputs;
-        CAmount remainder = total_reward % num_outputs;
 
         CMutableTransaction mutable_coinbase(*block.vtx.at(0));
         int witness_index = GetWitnessCommitmentIndex(block);
@@ -431,12 +438,33 @@ static RPCMethod generateblock()
             has_witness_commitment = true;
         }
 
-        mutable_coinbase.vout.clear();
-        for (size_t i = 0; i < num_outputs; ++i) {
-            CAmount out_reward = (i < static_cast<size_t>(remainder) ? reward_parted +1 : reward_parted);
-            CTxOut new_tx_out(out_reward, coinbase_outputs_scripts[i]);
-            mutable_coinbase.vout.push_back(new_tx_out);
+        if (!custom_rewards.empty()){
+            CAmount remainder = 0;
+            CAmount total_value = std::accumulate(custom_rewards.begin(), custom_rewards.end(), CAmount{0});
+            std::cout << "total_value=" << total_value << std::endl;
+            if (total_reward < total_value){
+                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("The parted reward introduced is bigger than the total reward of the block"));
+            } else if (total_reward > total_value){
+                remainder = (total_reward - total_value) / num_outputs;
+            }
+
+            mutable_coinbase.vout.clear();
+            for (size_t i = 0; i < num_outputs; ++i) {
+                CAmount out_reward = custom_rewards[i]+remainder;
+                CTxOut new_tx_out(out_reward, coinbase_outputs_scripts[i]);
+                mutable_coinbase.vout.push_back(new_tx_out);
+            }
+        } else {
+            CAmount remainder = total_reward % num_outputs;
+            CAmount reward_parted = total_reward / num_outputs;
+            mutable_coinbase.vout.clear();
+            for (size_t i = 0; i < num_outputs; ++i) {
+                CAmount out_reward = (i < static_cast<size_t>(remainder) ? reward_parted +1 : reward_parted);
+                CTxOut new_tx_out(out_reward, coinbase_outputs_scripts[i]);
+                mutable_coinbase.vout.push_back(new_tx_out);
+            }
         }
+
         if (has_witness_commitment) {
             mutable_coinbase.vout.push_back(witness_output);
         }

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -70,6 +70,25 @@ class RPCGenerateTest(BitcoinTestFramework):
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
         assert_equal(block['tx'][0]['vout'][1]['scriptPubKey']['address'], address2)
 
+        self.log.info('Generate an empty block to a list of descriptors with custom reward')
+        hash = self.generateblock(node, [{'addr(' + address + ')': 10*10**8},
+            {'addr('+ address2 + ')': 15*10**8}], [])['hash']
+        block = node.getblock(blockhash=hash, verbosity=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+        assert_equal(block['tx'][0]['vout'][1]['scriptPubKey']['address'], address2)
+        assert_equal(block['tx'][0]['vout'][0]['value'], 10)
+        assert_equal(block['tx'][0]['vout'][1]['value'], 15)
+
+        self.log.info('Generate an empty block to a list of addresses with custom reward')
+        hash = self.generateblock(node, [{address: 8*10**8}, {address2: 12*10**8}], [])['hash']
+        block = node.getblock(blockhash=hash, verbosity=2)
+        assert_equal(len(block['tx']), 1)
+        assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
+        assert_equal(block['tx'][0]['vout'][1]['scriptPubKey']['address'], address2)
+        assert_equal(block['tx'][0]['vout'][0]['value'], 10.5)
+        assert_equal(block['tx'][0]['vout'][1]['value'], 14.5)
+
         self.log.info('Generate an empty block to a combo descriptor with compressed pubkey')
         combo_key = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
         combo_address = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080'


### PR DESCRIPTION
Adding custom split reward in the generateblock rpc. Now in the `output` parameter it can also be passed the address an amount to each address: `[{addr1: 10}, {addr2: 20}]`. To save the custom rewards, a new vector, `custom_rewards`, has been created where we save the values corresponding to each address/descriptor in the loop where we get the scripts form the addresses/descriptors. Later we check if the `custom_rewards` is not empty to continue with the custom split reward logic.

Concerns with the curren approach:

- When the custom reward is higher than the block reward and `RPC_INVALID_PARAMETER` error is thrown (not sure if this is the rigth error for this case).
- Haven't changed the format how the rpc expects the `output` parameter since `skip_type_check` is set to true. Not sure if some chenges should be made here.
- If the custom reward is not exactly as the block reward, the reminder is split equally among the outputs. In some cases this could lead to not having the whole reward splited. Example (in sats):
```
addr1: 1000000000, addr2: 1000000003
total: 2000000003
block_reward: 2500000000
diff: 499999997
amount_per_address: 24999998
# So each outputs has these values:
addr1: 12.49999998
addr2: 12.50000001
# The sum of theses two doesn't equal to 25*10⁸
total: 24.99999999
```
Not sure if we should address this case or is it okey this behaviour.